### PR TITLE
MàJ PWA

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,9 +9,9 @@
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/favicon.ico",
+      "src": "/my-notion-face-portrait.png",
       "sizes": "512x512",
-      "type": "image/x-icon",
+      "type": "image/png",
       "purpose": "any maskable"
     }
   ]

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />
         <meta name="apple-mobile-web-app-title" content="Portfolio" />
-        <link rel="apple-touch-icon" href="/favicon.ico" />
+        <link rel="apple-touch-icon" href="/my-notion-face-portrait.png" />
       </head>
       <body className={inter.className}>
         <ClientLayout>{children}</ClientLayout>


### PR DESCRIPTION
This pull request updates the application's branding by replacing the favicon and Apple touch icon with a new image. The changes ensure consistency across the application's manifest and layout metadata.

### Branding updates:

* [`public/manifest.json`](diffhunk://#diff-639916bc14c3f311c31f629a2ec116292a4b2f64d06b3607b9ddd2e495703895L12-R14): Updated the `src` of the app icon from `/favicon.ico` to `/my-notion-face-portrait.png`, changed the `type` from `image/x-icon` to `image/png`, and retained the maskable purpose.
* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L23-R23): Updated the `href` for the Apple touch icon to `/my-notion-face-portrait.png` to reflect the new branding.