### PR TITLE
Develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js",
+    "start": "node server.js",
+    "start:prod": "NODE_ENV=production node server.js",
     "start:next": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
This pull request updates the way the production environment is handled in the `package.json` scripts. The main change is the separation of the production start command into its own script for clarity and flexibility.

Script management improvements:

* Modified the `start` script in `package.json` to no longer set `NODE_ENV=production` by default, making it suitable for non-production use cases.
* Added a new `start:prod` script in `package.json` that explicitly sets `NODE_ENV=production` for starting the server in production mode.