### PR TITLE
fix: désactivation complète des indicateurs de développement Next.js …

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,10 +13,22 @@ const nextConfig: NextConfig = {
   swcMinify: true,
   poweredByHeader: false,
   
-  // Désactiver l'indicateur de développement Next.js et les overlays
+  // Désactiver COMPLÈTEMENT l'indicateur de développement Next.js
   devIndicators: {
     buildActivity: false,
     buildActivityPosition: 'bottom-right',
+  },
+
+  // Désactiver Turbopack indicator si utilisé
+  experimental: {
+    turbo: {
+      rules: {},
+    },
+  },
+
+  // Configuration du compilateur
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production',
   },
 
   // Désactivation des outils de développement en production
@@ -41,10 +53,14 @@ const nextConfig: NextConfig = {
     ];
   },
 
-  // Variables d'environnement
+  // Variables d'environnement pour désactiver les indicateurs
   env: {
     NODE_ENV: process.env.NODE_ENV || 'development',
+    __NEXT_DISABLE_OVERLAY: 'true',
+    __NEXT_DISABLE_BUILD_INDICATOR: 'true',
   },
+
+
 };
 
 export default nextConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -180,3 +180,27 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Masquer complètement tous les indicateurs de développement Next.js */
+[data-nextjs-scroll-focus-boundary] {
+  display: none !important;
+}
+
+/* Masquer l'icône Next.js en bas à gauche */
+[data-nextjs-route-indicator],
+[data-nextjs-build-indicator],
+.__nextjs_build_indicator,
+.__next,
+.next-build-indicator {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+/* Masquer les overlays de développement */
+[data-nextjs-dialog-overlay],
+[data-nextjs-toast],
+[data-nextjs-portal] {
+  display: none !important;
+}


### PR DESCRIPTION
This pull request focuses on completely disabling all Next.js development indicators and overlays in both the application configuration and global styles. The goal is to ensure that no development UI elements are visible in any environment, especially production. The most important changes are grouped below by configuration updates and CSS overrides.

**Configuration updates:**

* Added new `experimental.turbo` and `compiler.removeConsole` options in `next.config.ts` to further disable development indicators and remove console logs in production.
* Updated environment variables in `next.config.ts` to explicitly disable overlays and build indicators by setting `__NEXT_DISABLE_OVERLAY` and `__NEXT_DISABLE_BUILD_INDICATOR` to `'true'`.

**CSS overrides:**

* Added CSS rules in `src/app/globals.css` to hide all Next.js development indicators, overlays, and icons, ensuring they do not appear in the UI.